### PR TITLE
Remove APPLICATIONINSIGHTS_CONNECTION_STRING from output

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -280,7 +280,7 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
 }
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.name
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -280,7 +280,6 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
 }
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixed the output for `APPLICATIONINSIGHTS_CONNECTION_STRING` that wasn't returning the actual string, which caused the post-hook scripts to fail on my machine.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run `azd provision` and verify that post-hook scripts run successfully.
* Run `azd env get-values` and verify that `APPLICATIONINSIGHTS_CONNECTION_STRING` contains a valid connection string.


## Other Information
<!-- Add any other helpful information that may be needed here. -->